### PR TITLE
Hover Effect On Tour Packages In Home & Tour Page

### DIFF
--- a/css/templatemo-style.css
+++ b/css/templatemo-style.css
@@ -375,6 +375,11 @@ hr { border-top: 1px solid #111010; }
 .tm-home-box-2 {
 	background-color: white;
 	max-width: 254px;
+	transition: all 0.3s ease-in-out;
+}
+.tm-home-box-2:hover {
+	scale: 1.1;
+	cursor:pointer;
 }
 .tm-home-box-2 h3 {
 	font-size: 14px;
@@ -428,6 +433,11 @@ hr { border-top: 1px solid #111010; }
 	margin-bottom: 50px;
 	max-width: 555px;
 	overflow: hidden;
+	transition: all 0.3s ease-in-out;
+}
+.tm-home-box-3:hover {
+	scale: 1.1;
+	cursor:pointer;
 }
 .tm-home-box-3-img-container { float: left; }
 .tm-home-box-3-info {
@@ -445,6 +455,11 @@ hr { border-top: 1px solid #111010; }
 	width: 100%;
 	max-width: 532px;
 	margin-bottom: 50px;
+	transition: all 0.3s ease-in-out;
+}
+.tm-tours-box-1:hover {
+	scale: 1.1;
+	cursor: pointer;
 }
 .tm-tours-box-1-info {
 	background: white;
@@ -498,6 +513,11 @@ hr { border-top: 1px solid #111010; }
 .tm-tours-box-2 {
 	max-width: 254px;
 	width: 100%;
+	transition: all 0.3s ease-in-out;
+}
+.tm-tours-box-2:hover {
+	scale: 1.1;
+	cursor: pointer;
 }
 .tm-tours-box-2-info h3 {
 	font-size: 14px;


### PR DESCRIPTION
## Related Issue
- Issue No. #151 
## Changes you made : 
- Added smooth scale effect while hover on tour packages on home and tours page

## Describe the changes :
- Added nice scale effect on tour packages cards, the tour packages on home and tours page will scale up on hover with transistion.

![image](https://user-images.githubusercontent.com/42407874/194568548-fc3273ef-4a80-48bd-b980-d5e2a1434faa.png)



## Check list :
<!-- Put `x` in the box whichever option is applicable to you -->
- [x] I have followed code style of this project.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Arun9739/Paryatana/blob/main/Contributing.md) document.
- [x] All the aspects mentioned in the issue are covered.
- [x] The website is properly working after my changes.
- [x] 🌟 ed the repo

### Type of change :
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Output Screenshots :

![image](https://user-images.githubusercontent.com/42407874/194568135-d1b99f84-d220-45b6-a9dd-6ba72970d37c.png)

![image](https://user-images.githubusercontent.com/42407874/194568012-bbc13c47-ec21-4c14-b6ba-762226dc1f61.png)

![image](https://user-images.githubusercontent.com/42407874/194568276-5c218612-93bf-4dcb-be4e-21aa809f80f8.png)


