### PR TITLE
Tours content overflow hidden fixed

### DIFF
--- a/css/templatemo-style.css
+++ b/css/templatemo-style.css
@@ -403,7 +403,7 @@ hr { border-top: 1px solid #111010; }
 .tm-tours-box-1-info-left,
 .tm-tours-box-1-info-right {
 	float: left;
-	width: 43%;
+	width: 50%;
 }
 .tm-tours-box-1-info-left {
 	border-right: 1px solid #B1B1B1;
@@ -413,7 +413,7 @@ hr { border-top: 1px solid #111010; }
 .margin-bottom-20 { margin-bottom: 20px; }
 .margin-bottom-30 { margin-bottom: 30px; }
 .gray-text { color: #B1B1B1; }
-.tours-1-description { line-height: 1.8; width: 251px;}
+.tours-1-description { line-height: 1.8; width: 100%;}
 #tm-tours-box-1-3{padding-top: 38px;padding-bottom: 38px;}
 .tm-tours-box-1-link { overflow: hidden }
 .tm-tours-box-1-link-left { 


### PR DESCRIPTION
## Related Issue
- Issue No. #227 

## Changes you made :
- Changed css in templatemo-style.css

## Describe the changes :
Changed width of 2 divs. Earlier due to fixed width, content was overflowing and was not visible but now changed the width to dynamic which made it responsive.


## Check list :
<!-- Put `x` in the box whichever option is applicable to you -->
- [x] I have followed code style of this project.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Arun9739/Paryatana/blob/main/Contributing.md) document.
- [x] All the aspects mentioned in the issue are covered.
- [x] The website is properly working after my changes.
- [x] 🌟 ed the repo

### Type of change :
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Output Screenshots :

![image](https://user-images.githubusercontent.com/54628090/195561344-db477abd-1bc4-46f3-b016-ae1e5c2953f0.png)

