### PR TITLE
Margin between "popular packages" cards

### DIFF
--- a/css/templatemo-style.css
+++ b/css/templatemo-style.css
@@ -364,8 +364,9 @@ hr { border-top: 1px solid #111010; }
 }
 
 .tm-home-box-3 {
-	margin-bottom: 50px;
-	max-width: 555px;
+	margin-bottom: 35px;
+	margin-right: 10px;
+	max-width: auto;
 	overflow: hidden;
 	transition: all 0.3s ease-in-out;
 }
@@ -373,15 +374,17 @@ hr { border-top: 1px solid #111010; }
 	scale: 1.1;
 	cursor:pointer;
 }
-.tm-home-box-3-img-container { float: left; }
+.tm-home-box-3-img-container { 
+	float: left; 
+}
 .tm-home-box-3-info {
     height: 225px;
-    max-width: 305px;
+    max-width: 295px;
     float: right;
     border: 1px solid #CCC;
 	border-left: none;
 }
-.tm-home-box-3-description { padding: 40px 30px 44px; }
+.tm-home-box-3-description { padding: 35px 25px 44px; }
 .section-padding-bottom { padding-bottom: 60px; }
 
 /* Tours */


### PR DESCRIPTION
## Related Issue
- Issue No. #259

## Changes you made :
- Give more margin between "popular packages" cards to maintain enough space while hovering over them

## Describe the changes :
- Change padding of "tm-home-box-3-description" class
- Add margin-right to "tm-home-box-3" class


## Check list :
<!-- Put `x` in the box whichever option is applicable to you -->
- [x] I have followed code style of this project.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Arun9739/Paryatana/blob/main/Contributing.md) document.
- [x] All the aspects mentioned in the issue are covered.
- [x] The website is properly working after my changes.
- [x] 🌟 ed the repo

### Type of change :
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Output Screenshots :

![image](https://user-images.githubusercontent.com/91800813/196033891-3747f7a7-15b3-44e6-b38f-672693449ed7.png)

