### PR TITLE
Update the copyright with current year automatically

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,7 +507,7 @@
 			</div>
 			<div class="bottom-footer">
 				<p id = "customer">Customer satisfaction is our first priority</p><br>
-				<p>Copyrights &copy 2022 Paryatana | Designed by <a  href = "https://www.linkedin.com/in/arun-g-nayak/" style = "text-decoration: none;">Arun G Nayak</a></p>
+				<p>Copyrights &copy <span id="copyrightYear">2022</span> Paryatana | Designed by <a  href = "https://www.linkedin.com/in/arun-g-nayak/" style = "text-decoration: none;">Arun G Nayak</a></p>
 			</div>
         </div>
         
@@ -540,6 +540,7 @@
 	<script type="text/javascript" src="js/jquery.flexslider-min.js"></script>
 
 	<script type="text/javascript" src="js/templatemo-script.js"></script> <!-- Templatemo Script -->
+	<script type="text/javascript" src="js/update-copyrightYear.js"></script> <!--Updating the copyright year-->
 	<script>
 		// HTML document is loaded. DOM is ready.
 		$(function () {

--- a/js/update-copyrightYear.js
+++ b/js/update-copyrightYear.js
@@ -1,0 +1,4 @@
+let currentDate = new Date();
+let currentYear = currentDate.getFullYear();
+
+document.getElementById("copyrightYear").innerText = currentYear;


### PR DESCRIPTION
## Related Issue
- closes #310 

## Changes you made :
- Using simple javascript, the current year in copyright gets automatically update each time accordingly.
**- This removes the effort to update the copyright year every time the calender year changes.**

## Describe the changes :
- This improves the overall experience of the users and viewers.

<!--- Why is this change required? What problem does it solve? -->
- Updating the copyright year each time helps the website to stay updated

## Check list :
<!-- Put `x` in the box whichever option is applicable to you -->
- [X] I have followed code style of this project.
- [X] I have read the [**CONTRIBUTING**](https://github.com/Arun9739/Paryatana/blob/main/Contributing.md) document.
- [X] All the aspects mentioned in the issue are covered.
- [X] The website is properly working after my changes.
- [X] 🌟 ed the repo

### Type of change :
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Output Screenshots :

<!-- Put the screenshot of the section(s) you have changed -->
For the year 2022,
![Screenshot from 2022-10-22 14-14-41](https://user-images.githubusercontent.com/97968307/197330102-ba6e72d3-e165-4512-af5e-07287cd3153a.png)
The next change will be automatically observed in 2023.

